### PR TITLE
Feature request: Output expressions directly as a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ And we can easily copy&paste those strings and plot the corresponding functions.
 | loadParams | Loads precalculated coefficients merging them into the current model internal store | Path \<string\> |
 | saveParams | Save the current model coefficients in a JSON file | Path \<string\> |
 | saveExpressions | Turn the current model coefficients into reusable expressions and save them in a JSON file | Path \<string\> |
+| expressions | Turn the current model coefficients into reusable expressions and return them as a variable | None |

--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,15 @@ const createModel = () => {
     },{});
     writeFileSync(path, JSON.stringify(paramsWithExpressions, null, 2));
   };
+  
+  const expressions = () => {
+    return Object.entries(params).reduce((acc,[degree,coefficients]) => {
+      acc[degree] = getExpression(coefficients);
+      return acc;
+    },{});
+  };
 
-  return { fit, estimate, loadParams, saveParams, saveExpressions };
+  return { fit, estimate, loadParams, saveParams, saveExpressions, expressions };
 };
 
 module.exports = {


### PR DESCRIPTION
Would you support getting the expressions outputted into a variable to further work on it or use it to process more data?

I imagine usage something like this:
```js
const calculatedExpressions = model.expressions()
console.log(calculatedExpressions)
```

My backup solution is to read the new JSON file just as it is created. But that seams silly to me. 